### PR TITLE
React calendar data renderer test

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -10,7 +10,7 @@ module.exports = (config) => {
     frameworks: ['mocha', 'sinon', 'chai'],
 
     files: [
-      'test/react/components/*',
+      'test/react/**/*',
     ],
 
     webpack: {

--- a/src/react/renderers/data/calendar.jsx
+++ b/src/react/renderers/data/calendar.jsx
@@ -180,4 +180,3 @@ export default ReactRenderer.register(
   Calendar,
   StaticCalendar
 );
-

--- a/src/react/renderers/data/index.jsx
+++ b/src/react/renderers/data/index.jsx
@@ -1,6 +1,6 @@
 export function withDataRenderer(WrappedComponent) {
   return ({viewType, renderData}) => {
-    const {getError, isDisabled, onChange, onBlur, nButtonClick} = renderData.options;
+    const {getError, isDisabled, onChange, onBlur, onButtonClick} = renderData.options;
 
     const ref = viewType.getRef();
     const disabled = isDisabled(ref) || !viewType.isEditable();
@@ -133,4 +133,3 @@ export function withDisplayRenderer(WrappedComponent) {
     />;
   };
 }
-

--- a/test/react/components/label_spec.jsx
+++ b/test/react/components/label_spec.jsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import chai, {expect} from 'chai';
 import chaiEnzyme from 'chai-enzyme';
-import sinon from 'sinon';
 import {shallow} from 'enzyme';
-import moment from 'moment';
 
 import 'formatron/types';
 import {Label} from 'formatron/react';

--- a/test/react/renderers/data/calendar_spec.jsx
+++ b/test/react/renderers/data/calendar_spec.jsx
@@ -85,19 +85,6 @@ describe('calendar renderer', () => {
     expect(getInput(wrapper)).to.have.value(formattedValue);
   });
 
-  it('uses the given type', () => {
-    const value = 999000;
-    const format = 'ss';
-    const dataType = new data.date('', {format});
-    const renderData = createRenderData({value, dataType});
-    const calendar = reactRenderers.renderTableCell(
-        new view.calendar(), renderData);
-    const wrapper = mount(calendar);
-
-    const formattedValue = formatValue(value, format);
-    expect(getInput(wrapper)).to.have.value(formattedValue);
-  });
-
   it('displays the new value after it is changed', () => {
     const dataType = new data.date();
     const renderData = createRenderData({dataType});

--- a/test/react/renderers/data/calendar_spec.jsx
+++ b/test/react/renderers/data/calendar_spec.jsx
@@ -78,13 +78,13 @@ describe('calendar renderer', () => {
   })
 
   it('displays the new value after it is changed', () => {
-    const value = 999000;
     const dataType = new data.date();
     const renderData = createRenderData({dataType});
     const calendar = reactRenderers.renderTableCell(
         new view.calendar(), renderData);
     const wrapper = mount(calendar);
 
+    const value = 999000;
     const formattedValue = formatValue(value, dataType.getFormat());
     expect(getInput(wrapper)).not.to.have.value(formattedValue);
 

--- a/test/react/renderers/data/calendar_spec.jsx
+++ b/test/react/renderers/data/calendar_spec.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import {Map} from 'immutable';
 import chai, {expect} from 'chai';
 import chaiEnzyme from 'chai-enzyme';
 import {mount} from 'enzyme';
@@ -37,11 +36,11 @@ describe('calendar renderer', () => {
   let clock;
 
   beforeEach(() => {
-    clock = sinon.useFakeTimers()
+    clock = sinon.useFakeTimers();
   });
 
   afterEach(() => {
-    clock.restore()
+    clock.restore();
   });
 
   it('renders without exploding', () => {
@@ -49,6 +48,7 @@ describe('calendar renderer', () => {
     const calendar = reactRenderers.renderTableCell(
         new view.calendar(), renderData);
     const wrapper = mount(calendar);
+
     expect(wrapper).to.be.present();
   })
 
@@ -90,7 +90,7 @@ describe('calendar renderer', () => {
 
     const newRenderData = createRenderData({dataType, value});
     wrapper.setProps({renderData: newRenderData});
-    clock.tick(1000)  // Wait for the debounce.
+    clock.tick(1000);  // Wait for the debounce.
     expect(getInput(wrapper)).to.have.value(formattedValue);
   })
 
@@ -106,7 +106,7 @@ describe('calendar renderer', () => {
     const formattedValue = formatValue(value, dataType.getFormat());
     getInput(wrapper).simulate('change', {target: {value: formattedValue}});
     getInput(wrapper).simulate('blur');
-    clock.tick(1000)  // Wait for the blur timeout.
+    clock.tick(1000);  // Wait for the blur timeout.
     expect(onChange.getCall(0).args[1]).to.equal(value);
   })
 })

--- a/test/react/renderers/data/calendar_spec.jsx
+++ b/test/react/renderers/data/calendar_spec.jsx
@@ -32,6 +32,14 @@ function getInput(wrapper) {
   return wrapper.find('input.formatron-input-inner');
 }
 
+function clickPickerDay(day) {
+  // Picker is attached to document body because of tether.
+  const tableCells = document.querySelectorAll('.formatron-datetime-picker td');
+  const cell = Array.prototype.find.call(
+      tableCells, t => t.textContent === String(day));
+  cell.click();
+}
+
 describe('calendar renderer', () => {
   let clock;
 
@@ -50,7 +58,7 @@ describe('calendar renderer', () => {
     const wrapper = mount(calendar);
 
     expect(wrapper).to.be.present();
-  })
+  });
 
   it('displays the initial value', () => {
     const value = 999000;
@@ -62,7 +70,7 @@ describe('calendar renderer', () => {
 
     const formattedValue = formatValue(value, dataType.getFormat());
     expect(getInput(wrapper)).to.have.value(formattedValue);
-  })
+  });
 
   it('uses the given format', () => {
     const value = 999000;
@@ -75,7 +83,20 @@ describe('calendar renderer', () => {
 
     const formattedValue = formatValue(value, format);
     expect(getInput(wrapper)).to.have.value(formattedValue);
-  })
+  });
+
+  it('uses the given type', () => {
+    const value = 999000;
+    const format = 'ss';
+    const dataType = new data.date('', {format});
+    const renderData = createRenderData({value, dataType});
+    const calendar = reactRenderers.renderTableCell(
+        new view.calendar(), renderData);
+    const wrapper = mount(calendar);
+
+    const formattedValue = formatValue(value, format);
+    expect(getInput(wrapper)).to.have.value(formattedValue);
+  });
 
   it('displays the new value after it is changed', () => {
     const dataType = new data.date();
@@ -92,7 +113,7 @@ describe('calendar renderer', () => {
     wrapper.setProps({renderData: newRenderData});
     clock.tick(1000);  // Wait for the debounce.
     expect(getInput(wrapper)).to.have.value(formattedValue);
-  })
+  });
 
   it('accepts text input and calls onChange after blur', () => {
     const dataType = new data.date();
@@ -104,9 +125,33 @@ describe('calendar renderer', () => {
 
     const value = 999000;
     const formattedValue = formatValue(value, dataType.getFormat());
+
+    // Simulate entering text input.
     getInput(wrapper).simulate('change', {target: {value: formattedValue}});
+    // Blur to trigger onChange.
     getInput(wrapper).simulate('blur');
     clock.tick(1000);  // Wait for the blur timeout.
+
     expect(onChange.getCall(0).args[1]).to.equal(value);
-  })
+  });
+
+  it('accepts datetime picker input', () => {
+    const dataType = new data.date();
+    const onChange = sinon.spy();
+    const renderData = createRenderData({dataType, onChange});
+    const calendar = reactRenderers.renderTableCell(
+        new view.calendar(), renderData);
+    const wrapper = mount(calendar);
+
+    // Open the datetime picker.
+    getInput(wrapper).simulate('focus');
+    // Click on the 10th day.
+    clickPickerDay(10);
+    // Blur to trigger onChange.
+    getInput(wrapper).simulate('blur');
+    clock.tick(1000);  // Wait for the blur timeout.
+
+    const dayOfMonth = formatValue(onChange.getCall(0).args[1], 'D');
+    expect(dayOfMonth).to.equal(String(10));
+  });
 })

--- a/test/react/renderers/data/calendar_spec.jsx
+++ b/test/react/renderers/data/calendar_spec.jsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import {Map} from 'immutable';
+import chai, {expect} from 'chai';
+import chaiEnzyme from 'chai-enzyme';
+import {mount} from 'enzyme';
+import moment from 'moment';
+import sinon from 'sinon';
+
+import {view, data} from 'formatron/types';
+import RenderData from 'formatron/renderers/renderData'
+import reactRenderers from '~/react/renderers'
+
+chai.use(chaiEnzyme());
+
+function createRenderData(options = {}) {
+  return new RenderData(
+    options.dataType || new data.date(),
+    options.value || 0,
+    {
+      onChange: options.onChange || (() => {}),
+      onBlur: options.onBlur || (() => {}),
+      isDisabled: () => options.disabled || false,
+      getError: () => options.error || false,
+      isEditable: () => options.editable || true,
+    });
+}
+
+function formatValue(value, format) {
+  return moment(new Date(value * 1000)).format(format);
+}
+
+function getInput(wrapper) {
+  return wrapper.find('input.formatron-input-inner');
+}
+
+describe('calendar renderer', () => {
+  let clock;
+
+  beforeEach(() => {
+    clock = sinon.useFakeTimers()
+  });
+
+  afterEach(() => {
+    clock.restore()
+  });
+
+  it('renders without exploding', () => {
+    const renderData = createRenderData();
+    const calendar = reactRenderers.renderTableCell(
+        new view.calendar(), renderData);
+    const wrapper = mount(calendar);
+    expect(wrapper).to.be.present();
+  })
+
+  it('displays the initial value', () => {
+    const value = 999000;
+    const dataType = new data.date();
+    const renderData = createRenderData({value, dataType});
+    const calendar = reactRenderers.renderTableCell(
+        new view.calendar(), renderData);
+    const wrapper = mount(calendar);
+
+    const formattedValue = formatValue(value, dataType.getFormat());
+    expect(getInput(wrapper)).to.have.value(formattedValue);
+  })
+
+  it('uses the given format', () => {
+    const value = 999000;
+    const format = 'ss';
+    const dataType = new data.date('', {format});
+    const renderData = createRenderData({value, dataType});
+    const calendar = reactRenderers.renderTableCell(
+        new view.calendar(), renderData);
+    const wrapper = mount(calendar);
+
+    const formattedValue = formatValue(value, format);
+    expect(getInput(wrapper)).to.have.value(formattedValue);
+  })
+
+  it('displays the new value after it is changed', () => {
+    const value = 999000;
+    const dataType = new data.date();
+    const renderData = createRenderData({dataType});
+    const calendar = reactRenderers.renderTableCell(
+        new view.calendar(), renderData);
+    const wrapper = mount(calendar);
+
+    const formattedValue = formatValue(value, dataType.getFormat());
+    expect(getInput(wrapper)).not.to.have.value(formattedValue);
+
+    const newRenderData = createRenderData({dataType, value});
+    wrapper.setProps({renderData: newRenderData});
+    clock.tick(1000)  // Wait for the debounce.
+    expect(getInput(wrapper)).to.have.value(formattedValue);
+  })
+
+  it('accepts text input and calls onChange after blur', () => {
+    const dataType = new data.date();
+    const onChange = sinon.spy();
+    const renderData = createRenderData({dataType, onChange});
+    const calendar = reactRenderers.renderTableCell(
+        new view.calendar(), renderData);
+    const wrapper = mount(calendar);
+
+    const value = 999000;
+    const formattedValue = formatValue(value, dataType.getFormat());
+    getInput(wrapper).simulate('change', {target: {value: formattedValue}});
+    getInput(wrapper).simulate('blur');
+    clock.tick(1000)  // Wait for the blur timeout.
+    expect(onChange.getCall(0).args[1]).to.equal(value);
+  })
+})


### PR DESCRIPTION
The withDisplayRenderer() wrapper makes testing a bit painful. I could export a direct reference to <CalendarInput> used by tests only, but adding test only things is lame.

TODO: 
 - add tests for 'date' and 'time' only modes
 - add tests for date picker interaction