### PR TITLE
Use gray calendar color scheme

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "react-tether": "^0.5.6",
     "react-virtualized": "^9.7.2",
     "react-virtualized-select": "^3.0.1",
-    "yet-another-datetime-picker": "^0.4.6"
+    "yet-another-datetime-picker": "^1.0.1"
   },
   "devDependencies": {
     "autoprefixer": "^7.1.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "react-tether": "^0.5.6",
     "react-virtualized": "^9.7.2",
     "react-virtualized-select": "^3.0.1",
-    "yet-another-datetime-picker": "^1.0.1"
+    "yet-another-datetime-picker": "^1.0.4"
   },
   "devDependencies": {
     "autoprefixer": "^7.1.1",

--- a/src/react/renderers/data/calendar.jsx
+++ b/src/react/renderers/data/calendar.jsx
@@ -1,121 +1,123 @@
-import debounce from 'debounce';
-import moment from 'moment';
-import TetheredComponent from 'react-tether';
-import DatetimePicker from 'yet-another-datetime-picker';
+import debounce from 'debounce'
+import moment from 'moment'
+import TetheredComponent from 'react-tether'
+import DatetimePicker from 'yet-another-datetime-picker'
 
-import FormatronPropTypes from '~/react/propTypes';
-import DateType from '~/types/data/date';
-import CalendarType from '~/types/view/data/calendar';
+import FormatronPropTypes from '~/react/propTypes'
+import DateType from '~/types/data/date'
+import CalendarType from '~/types/view/data/calendar'
 
-import {withFormLabel, withStaticLabel} from '../formHelpers';
-import ReactRenderer from '../reactRenderer';
-import {TableRangeFilter} from '../tableHelpers';
-import {withDataRenderer, withDisplayRenderer} from './';
+import { withFormLabel, withStaticLabel } from '../formHelpers'
+import ReactRenderer from '../reactRenderer'
+import { TableRangeFilter } from '../tableHelpers'
+import { withDataRenderer, withDisplayRenderer } from './'
 
-const CalendarFilter = ({viewType, renderData}) => (
+const CalendarFilter = ({ viewType, renderData }) =>
   <TableRangeFilter
     viewType={viewType}
     renderData={renderData}
     parse={value => renderData.dataType.convert(value, 'unix')}
     Component={CalendarInput}
   />
-);
 
 const CalendarInputPropTypes = {
   field: FormatronPropTypes.dataType.instanceOf(DateType).isRequired,
   value: React.PropTypes.any,
   disabled: React.PropTypes.bool,
   onChange: React.PropTypes.func.isRequired,
-  onBlur: React.PropTypes.func.isRequired
-};
+  onBlur: React.PropTypes.func.isRequired,
+}
 
 class CalendarInput extends React.Component {
   constructor(props) {
-    super(props);
-    this.blurTimeout = 0;
-    this.state = this.createInitialState(props);
+    super(props)
+    this.blurTimeout = 0
+    this.state = this.createInitialState(props)
   }
 
   // Debounce greatly improves time picker slider performance.
-  componentWillReceiveProps = debounce((props) => {
-    this.setState({input: this.createInitialState(props).input});
-  }, 15);
+  componentWillReceiveProps = debounce(props => {
+    this.setState({ input: this.createInitialState(props).input })
+  }, 15)
 
   handleFocus = () => {
-    clearTimeout(this.blurTimeout);
-    this.setState({showPicker: true});
+    clearTimeout(this.blurTimeout)
+    this.setState({ showPicker: true })
   }
 
   handleBlur = () => {
     // Wait for possible focus event before handling the blur event.
     this.blurTimeout = setTimeout(() => {
-      this.saveInput();
-      this.setState({showPicker: false});
-      this.props.onBlur();
-    });
+      this.saveInput()
+      this.setState({ showPicker: false })
+      this.props.onBlur()
+    })
   }
 
   saveInput = () => {
-    this.props.onChange(this.props.field.convert(this.state.input, 'unix'));
+    this.props.onChange(this.props.field.convert(this.state.input, 'unix'))
   }
 
-  handlePickerChange = (datetime) => {
-    this.setState({input: this.props.field.convert(datetime, 'string')});
+  handlePickerChange = datetime => {
+    this.setState({ input: this.props.field.convert(datetime, 'string') })
   }
 
-  handleInputChange = (event) => {
-    this.setState({input: event.target.value});
+  handleInputChange = event => {
+    this.setState({ input: event.target.value })
   }
 
   handleClearInput = e => {
-    e.stopPropagation();
-    e.preventDefault();
-    clearTimeout(this.blurTimeout);
-    this.setState({input: ''}, this.handleBlur);
+    e.stopPropagation()
+    e.preventDefault()
+    clearTimeout(this.blurTimeout)
+    this.setState({ input: '' }, this.handleBlur)
   }
 
-  handleEnter = (event) => {
+  handleEnter = event => {
     if (event.which == 13) {
-      event.preventDefault();
-      event.stopPropagation();
-      this.handleBlur();
+      event.preventDefault()
+      event.stopPropagation()
+      this.handleBlur()
     }
   }
 
   createInitialState(props) {
     return {
       showPicker: false,
-      input: props.field.convert(props.value, 'string')
-    };
+      input: props.field.convert(props.value, 'string'),
+    }
   }
 
   getPickerDatetime() {
     if (!this.state.input) {
-      return moment();
+      return moment()
     }
-    return this.props.field.convert(this.state.input, 'datetime');
+    return this.props.field.convert(this.state.input, 'datetime')
   }
 
   renderPicker() {
     return (
       <TetheredComponent
         classes={{
-          element: 'formatron-tether-element-top'
+          element: 'formatron-tether-element-top',
         }}
-        renderElementTo='body'
-        attachment='top left'
-        targetAttachment='bottom left'
-        constraints={[{
-          to: 'scrollParent',
-          attachment: 'together'
-        }, {
-          to: 'window',
-          attachment: 'together'
-        }]}
+        renderElementTo="body"
+        attachment="top left"
+        targetAttachment="bottom left"
+        constraints={[
+          {
+            to: 'scrollParent',
+            attachment: 'together',
+          },
+          {
+            to: 'window',
+            attachment: 'together',
+          },
+        ]}
       >
-        <div className='formatron-tether-target' />
+        <div className="formatron-tether-target" />
         <DatetimePicker
-          className='formatron-datetime-picker'
+          className="formatron-datetime-picker"
           onFocusCapture={this.handleFocus}
           onBlur={this.handleBlur}
           moment={this.getPickerDatetime()}
@@ -123,23 +125,26 @@ class CalendarInput extends React.Component {
           onDone={this.handleBlur}
           onKeyPress={this.handleEnter}
           type={this.props.field.getType()}
-          prevMonthIcon='fa fa-angle-left'
-          nextMonthIcon='fa fa-angle-right'
-          doneIcon='fa fa-check'
-          dateIcon='fa fa-calendar'
-          timeIcon='fa fa-clock-o'
+          theme={{
+            colorPrimary: '#606060',
+            iconPrevMonth: 'fa fa-angle-left',
+            iconNextMonth: 'fa fa-angle-right',
+            iconDone: 'fa fa-check',
+            iconDate: 'fa fa-calendar',
+            iconTime: 'fa fa-clock-o',
+          }}
         />
       </TetheredComponent>
-    );
+    )
   }
 
   render() {
-    const {field, disabled, placeholder} = this.props;
+    const { field, disabled, placeholder } = this.props
     return (
-      <div className='formatron-input formatron-calendar'>
+      <div className="formatron-input formatron-calendar">
         <input
-          className='formatron-input-inner'
-          type='text'
+          className="formatron-input-inner"
+          type="text"
           value={this.state.input}
           onFocus={this.handleFocus}
           onBlur={this.handleBlur}
@@ -148,29 +153,34 @@ class CalendarInput extends React.Component {
           placeholder={placeholder}
           disabled={disabled}
         />
-        {(!disabled && this.state.input) ? (
-          <button className='formatron-field-action' onClick={this.handleClearInput}>
-            <span>{'\u00D7'}</span>
-          </button>
-        ) : null}
+        {!disabled && this.state.input
+          ? <button
+              className="formatron-field-action"
+              onClick={this.handleClearInput}
+            >
+              <span>
+                {'\u00D7'}
+              </span>
+            </button>
+          : null}
         {this.state.showPicker && !disabled ? this.renderPicker() : null}
       </div>
-    );
+    )
   }
 }
 
-CalendarInput.propTypes = CalendarInputPropTypes;
+CalendarInput.propTypes = CalendarInputPropTypes
 
-const Calendar = withDataRenderer(props => (
-  <CalendarInput {...props} />
-));
+const Calendar = withDataRenderer(props => <CalendarInput {...props} />)
 
-const StaticCalendar = withDisplayRenderer(({field, value}) => (
-  <p className='formatron-static-value'>{value}</p>
-));
+const StaticCalendar = withDisplayRenderer(({ field, value }) =>
+  <p className="formatron-static-value">
+    {value}
+  </p>
+)
 
-const CalendarField = withFormLabel(Calendar);
-const StaticCalendarField = withStaticLabel(StaticCalendar);
+const CalendarField = withFormLabel(Calendar)
+const StaticCalendarField = withStaticLabel(StaticCalendar)
 
 export default ReactRenderer.register(
   CalendarType,
@@ -179,4 +189,4 @@ export default ReactRenderer.register(
   CalendarFilter,
   Calendar,
   StaticCalendar
-);
+)

--- a/src/react/renderers/data/calendar.jsx
+++ b/src/react/renderers/data/calendar.jsx
@@ -1,24 +1,24 @@
-import debounce from 'debounce'
-import moment from 'moment'
-import TetheredComponent from 'react-tether'
-import DatetimePicker from 'yet-another-datetime-picker'
+import debounce from 'debounce';
+import moment from 'moment';
+import TetheredComponent from 'react-tether';
+import DatetimePicker from 'yet-another-datetime-picker';
 
-import FormatronPropTypes from '~/react/propTypes'
-import DateType from '~/types/data/date'
-import CalendarType from '~/types/view/data/calendar'
+import FormatronPropTypes from '~/react/propTypes';
+import DateType from '~/types/data/date';
+import CalendarType from '~/types/view/data/calendar';
 
-import { withFormLabel, withStaticLabel } from '../formHelpers'
-import ReactRenderer from '../reactRenderer'
-import { TableRangeFilter } from '../tableHelpers'
-import { withDataRenderer, withDisplayRenderer } from './'
+import {withFormLabel, withStaticLabel} from '../formHelpers';
+import ReactRenderer from '../reactRenderer';
+import {TableRangeFilter} from '../tableHelpers';
+import {withDataRenderer, withDisplayRenderer} from './';
 
-const CalendarFilter = ({ viewType, renderData }) =>
+const CalendarFilter = ({viewType, renderData}) =>
   <TableRangeFilter
     viewType={viewType}
     renderData={renderData}
     parse={value => renderData.dataType.convert(value, 'unix')}
     Component={CalendarInput}
-  />
+  />;
 
 const CalendarInputPropTypes = {
   field: FormatronPropTypes.dataType.instanceOf(DateType).isRequired,
@@ -26,73 +26,73 @@ const CalendarInputPropTypes = {
   disabled: React.PropTypes.bool,
   onChange: React.PropTypes.func.isRequired,
   onBlur: React.PropTypes.func.isRequired,
-}
+};
 
 class CalendarInput extends React.Component {
   constructor(props) {
-    super(props)
-    this.blurTimeout = 0
-    this.state = this.createInitialState(props)
+    super(props);
+    this.blurTimeout = 0;
+    this.state = this.createInitialState(props);
   }
 
   // Debounce greatly improves time picker slider performance.
   componentWillReceiveProps = debounce(props => {
-    this.setState({ input: this.createInitialState(props).input })
-  }, 15)
+    this.setState({input: this.createInitialState(props).input});
+  }, 15);
 
   handleFocus = () => {
-    clearTimeout(this.blurTimeout)
-    this.setState({ showPicker: true })
-  }
+    clearTimeout(this.blurTimeout);
+    this.setState({showPicker: true});
+  };
 
   handleBlur = () => {
     // Wait for possible focus event before handling the blur event.
     this.blurTimeout = setTimeout(() => {
-      this.saveInput()
-      this.setState({ showPicker: false })
-      this.props.onBlur()
-    })
-  }
+      this.saveInput();
+      this.setState({showPicker: false});
+      this.props.onBlur();
+    });
+  };
 
   saveInput = () => {
-    this.props.onChange(this.props.field.convert(this.state.input, 'unix'))
-  }
+    this.props.onChange(this.props.field.convert(this.state.input, 'unix'));
+  };
 
   handlePickerChange = datetime => {
-    this.setState({ input: this.props.field.convert(datetime, 'string') })
-  }
+    this.setState({input: this.props.field.convert(datetime, 'string')});
+  };
 
   handleInputChange = event => {
-    this.setState({ input: event.target.value })
-  }
+    this.setState({input: event.target.value});
+  };
 
   handleClearInput = e => {
-    e.stopPropagation()
-    e.preventDefault()
-    clearTimeout(this.blurTimeout)
-    this.setState({ input: '' }, this.handleBlur)
-  }
+    e.stopPropagation();
+    e.preventDefault();
+    clearTimeout(this.blurTimeout);
+    this.setState({input: ''}, this.handleBlur);
+  };
 
   handleEnter = event => {
     if (event.which == 13) {
-      event.preventDefault()
-      event.stopPropagation()
-      this.handleBlur()
+      event.preventDefault();
+      event.stopPropagation();
+      this.handleBlur();
     }
-  }
+  };
 
   createInitialState(props) {
     return {
       showPicker: false,
       input: props.field.convert(props.value, 'string'),
-    }
+    };
   }
 
   getPickerDatetime() {
     if (!this.state.input) {
-      return moment()
+      return moment();
     }
-    return this.props.field.convert(this.state.input, 'datetime')
+    return this.props.field.convert(this.state.input, 'datetime');
   }
 
   renderPicker() {
@@ -135,11 +135,11 @@ class CalendarInput extends React.Component {
           }}
         />
       </TetheredComponent>
-    )
+    );
   }
 
   render() {
-    const { field, disabled, placeholder } = this.props
+    const {field, disabled, placeholder} = this.props;
     return (
       <div className="formatron-input formatron-calendar">
         <input
@@ -165,22 +165,22 @@ class CalendarInput extends React.Component {
           : null}
         {this.state.showPicker && !disabled ? this.renderPicker() : null}
       </div>
-    )
+    );
   }
 }
 
-CalendarInput.propTypes = CalendarInputPropTypes
+CalendarInput.propTypes = CalendarInputPropTypes;
 
-const Calendar = withDataRenderer(props => <CalendarInput {...props} />)
+const Calendar = withDataRenderer(props => <CalendarInput {...props} />);
 
-const StaticCalendar = withDisplayRenderer(({ field, value }) =>
+const StaticCalendar = withDisplayRenderer(({field, value}) =>
   <p className="formatron-static-value">
     {value}
   </p>
-)
+);
 
-const CalendarField = withFormLabel(Calendar)
-const StaticCalendarField = withStaticLabel(StaticCalendar)
+const CalendarField = withFormLabel(Calendar);
+const StaticCalendarField = withStaticLabel(StaticCalendar);
 
 export default ReactRenderer.register(
   CalendarType,
@@ -189,4 +189,4 @@ export default ReactRenderer.register(
   CalendarFilter,
   Calendar,
   StaticCalendar
-)
+);

--- a/src/theme/view.sass
+++ b/src/theme/view.sass
@@ -1,5 +1,3 @@
-$datepicker-color: #606060;
-
 // Field
 .formatron-field
   display: block
@@ -111,7 +109,7 @@ $datepicker-color: #606060;
     height: 34px
     text-align: center
     line-height: 32px
-    color: $datepicker-color
+    color: #606060
     font-family: FontAwesome
     cursor: pointer
     content: '\f073'
@@ -128,14 +126,6 @@ $datepicker-color: #606060;
 
   table
     line-height: 21px
-
-  .u-slider-time
-    .value
-      background-color: $datepicker-color
-
-  .u-slider-time
-    .handle::after
-      border-color: $datepicker-color
 
 // Checkbox
 .formatron-field-checkbox

--- a/src/theme/view.sass
+++ b/src/theme/view.sass
@@ -1,3 +1,5 @@
+$datepicker-color: #606060;
+
 // Field
 .formatron-field
   display: block
@@ -109,7 +111,7 @@
     height: 34px
     text-align: center
     line-height: 32px
-    color: #606060
+    color: $datepicker-color
     font-family: FontAwesome
     cursor: pointer
     content: '\f073'
@@ -129,11 +131,11 @@
 
   .u-slider-time
     .value
-      background-color: #606060
+      background-color: $datepicker-color
 
   .u-slider-time
     .handle::after
-      border-color: #606060
+      border-color: $datepicker-color
 
 // Checkbox
 .formatron-field-checkbox

--- a/src/theme/view.sass
+++ b/src/theme/view.sass
@@ -109,7 +109,7 @@
     height: 34px
     text-align: center
     line-height: 32px
-    color: #1385e5
+    color: #606060
     font-family: FontAwesome
     cursor: pointer
     content: '\f073'
@@ -126,6 +126,14 @@
 
   table
     line-height: 21px
+
+  .u-slider-time
+    .value
+      background-color: #606060
+
+  .u-slider-time
+    .handle::after
+      border-color: #606060
 
 // Checkbox
 .formatron-field-checkbox
@@ -322,4 +330,3 @@
   color: inherit
   font: inherit
   resize: vertical
-


### PR DESCRIPTION
Made a bunch of changes to yet-another-datetime-picker to clean up the code and allow theming. The calendar now matches the production color scheme :smile: 

Also includes prettier changes, which makes it a bit harder to read... maybe I'll submit those as a separate change next time.

<img width="459" alt="screen shot 2017-08-09 at 11 56 52 pm" src="https://user-images.githubusercontent.com/529205/29158123-ad21fefe-7d5e-11e7-84d3-c328d6e011f9.png">
