### PR TITLE
Fix tab resizing issue

### DIFF
--- a/src/theme/view.sass
+++ b/src/theme/view.sass
@@ -263,6 +263,9 @@
   justify-content: flex-start
   align-items: stretch
 
+.formatron-grid-inner > div
+  width: 100%
+
 // Header
 .formatron-header
   align-self: stretch
@@ -307,7 +310,6 @@
     [role=tablist]
       display: flex
       flex-flow: row nowrap
-      max-width: 100%
 
 // Text
 .formatron-textarea


### PR DESCRIPTION
Check out these radical screenshots:

lots of tabs
<img width="1290" alt="screen shot 2017-08-16 at 3 38 44 pm" src="https://user-images.githubusercontent.com/529205/29388597-6e53c5ae-829a-11e7-8251-88723f108f9d.png">

no content
<img width="1295" alt="screen shot 2017-08-16 at 3 38 29 pm" src="https://user-images.githubusercontent.com/529205/29388591-6ada853e-829a-11e7-8209-4c00019be9ab.png">

few tabs
<img width="1291" alt="screen shot 2017-08-16 at 3 39 00 pm" src="https://user-images.githubusercontent.com/529205/29388599-6fab4cce-829a-11e7-9d47-9036b58381c5.png">
